### PR TITLE
Fixed PHP Fatal error: Class 'Terminus\Models\Collections\Sites' not …

### DIFF
--- a/Commands/AnalyzeTableCommand.php
+++ b/Commands/AnalyzeTableCommand.php
@@ -2,7 +2,7 @@
 namespace Terminus\Commands;
 
 use Terminus\Commands\TerminusCommand;
-use Terminus\Models\Collections\Sites;
+use Terminus\Collections\Sites;
 
 /**
  * Analyzes tables from the client database.

--- a/Commands/BlobBlotterCommand.php
+++ b/Commands/BlobBlotterCommand.php
@@ -2,7 +2,7 @@
 namespace Terminus\Commands;
 
 use Terminus\Commands\TerminusCommand;
-use Terminus\Models\Collections\Sites;
+use Terminus\Collections\Sites;
 
 /**
  * Finds and problematic blob values from MariaDB.


### PR DESCRIPTION
…found in AnalyzeTableCommand.php:24 and BlobBlotterCommand.php:27

Gets this plugin working with the latest Terminus version 0.13.3.
