### PR TITLE
Fix @default-format annotation

### DIFF
--- a/src/BlobBlotterCommand.php
+++ b/src/BlobBlotterCommand.php
@@ -77,7 +77,7 @@ class BlobBlotterCommand extends TerminusCommand implements SiteAwareInterface {
    *
    * @command blob:cells
    *
-   * @default-format: table
+   * @default-format table
    * 
    * @return RowsOfFields
    * 


### PR DESCRIPTION
Annotations containing a `:` are rejected by phpdocumentor version 3.2.0 and later.  Using this was fine in earlier versions of phpdocumentor (Terminus version 1.4.1 and earlier), but this will break in a future Terminus release.